### PR TITLE
Fixing-Content-Security-Policy-directive-error-by-Heroku_HASEEB-KHALIL

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
+		<meta http-equiv="Content-Security-Policy" content="default-src *;
+   img-src * 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *;
+   style-src  'self' 'unsafe-inline' *">
 		<title>Booster</title>
 	</head>
 	<body>


### PR DESCRIPTION
Trying to fix error by Heroku regarding images.
error:"Refused to load the image '<URL>' because it violates the following Content Security Policy directive: "img-src 'self' data:"."

Fix:<meta http-equiv="Content-Security-Policy" content="default-src *;
   img-src * 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *;
   style-src  'self' 'unsafe-inline' *">


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have carefully reviewed my own code
- [x] I have commented my code
- [x] I have updated any documentation
