### PR TITLE
Meta-tag-in-html-doesn't-fix-the-issue_HASEEB-KHALIL

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -2,9 +2,6 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<meta http-equiv="Content-Security-Policy" content="default-src *;
-   img-src * 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *;
-   style-src  'self' 'unsafe-inline' *">
 		<title>Booster</title>
 	</head>
 	<body>


### PR DESCRIPTION
Met tag 
`<meta http-equiv="Content-Security-Policy" content="default-src *;
   img-src * 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *;
   style-src  'self' 'unsafe-inline' *">`
   Does not fix the issue

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have carefully reviewed my own code
- [x] I have commented my code
- [x] I have updated any documentation
